### PR TITLE
Countermeasures against being closed without using the "クローズする" button

### DIFF
--- a/src/handleReopenNotify.js
+++ b/src/handleReopenNotify.js
@@ -21,6 +21,7 @@ import {
  */
 export async function handleReopenNotify(logger, entry, thread, setting) {
   logger.info(`"${thread.name}" (${thread.id}) has been reopened.`)
+  if (entry.executorId === thread.client.user.id) return
   if (!entry.executorId) {
     await thread.send(setting.onReopen())
     return
@@ -43,6 +44,12 @@ export async function handleReopenNotify(logger, entry, thread, setting) {
       error instanceof DiscordjsError &&
       error.code === DiscordjsErrorCodes.InteractionCollectorError
     ) {
+      if (thread.archived) {
+        await thread.setArchived(false)
+        await message.delete()
+        await thread.setArchived()
+        return
+      }
       await message.edit({
         content: setting.onReopenButtonRejected(entry.executorId),
         components: [],


### PR DESCRIPTION
解決すること
- 投稿が再オープンされた後5分以内に「クローズする」ボタン以外の手段でクローズされると、5分経過後メッセージを編集できずエラー終了する

「〇〇がスレッドを再開しました。」の掲示理由は「オープンになっている投稿の状況を把握できるようにするためであり、ロギング目的ではない」と解釈した故、
5分経過時にクローズしてあるのならば再開メッセージを消すようにした。